### PR TITLE
Remove leftover exit(0) that aborts the pipeline after Parameter Assembly

### DIFF
--- a/Laboratory/Experiments/Protocol_4_Assembly/Assembly_Doctor.py
+++ b/Laboratory/Experiments/Protocol_4_Assembly/Assembly_Doctor.py
@@ -30,7 +30,6 @@ def parameter_assembly_protocol(config:dict, debug:bool) -> dict:
         config = amber_assembly_protocol(config)
     elif assemblyProtocol.upper() == "CGENFF":
         config = CGenFF_assembly_protocol(config)
-    exit(0)
     config.setdefault("checkpointInfo", {})["assemblyComplete"] = True
     return config
     


### PR DESCRIPTION
## Problem

`parameter_assembly_protocol()` in `Laboratory/Experiments/Protocol_4_Assembly/Assembly_Doctor.py` calls `exit(0)` right after dispatching the assembly protocol, **before** marking the checkpoint complete and returning:

```python
    elif assemblyProtocol.upper() == "CGENFF":
        config = CGenFF_assembly_protocol(config)
    exit(0)                                                     # <-- here
    config.setdefault("checkpointInfo", {})["assemblyComplete"] = True
    return config
```

This terminates the entire run immediately after stage `04_parameter_assembly` for **all three** assembly paths (AGNOSTIC / ANTECHAMBER / CGENFF). Torsion scanning, torsion fitting, final `.lib`/`.mol2` creation and reporting never run.

Because the exit status is **0**, schedulers (SLURM etc.) report the job as `COMPLETED` and no traceback is printed. The only visible symptom is that `checkpointInfo.assemblyComplete` stays `false` and no final parameters are produced — easy to mistake for a silent success. It looks like a leftover debug breakpoint.

## Fix

Remove the stray `exit(0)` so the function sets `assemblyComplete = True` and returns, allowing the pipeline to continue to torsion scanning → fitting → final creation.

## How it was found

Parameterising a non-canonical residue (a hydroxyproline) with the ANTECHAMBER/AMBER path: GOAT + RESP charges completed, `04_parameter_assembly` produced `mol2`+`frcmod`, then the job exited `COMPLETED` in seconds with no final lib and `assemblyComplete: false` in the checkpoint snapshot.