### PR TITLE
GOAT: fall back to serial when no MPI runtime is available

### DIFF
--- a/Laboratory/OperatingTools/drOrca.py
+++ b/Laboratory/OperatingTools/drOrca.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from os import path as p
 from subprocess import call
 ## CLEAN CODE ##
@@ -170,6 +171,16 @@ def write_goat_input(conformerDir: DirectoryPath, cappedXyz: FilePath, config: d
     goatOrcaInput = p.join(conformerDir, f"GOAT_orca.inp")
 
     useCpus = min(availableCpus, 16) ## limit to 16 cpus for GOAT to avoid overloading the system
+    ## ORCA only parallelises GOAT through MPI. If no MPI runtime is on PATH,
+    ## requesting NPROCS > 1 makes ORCA shell out to "mpirun" and abort with
+    ## "mpirun: not found": no *.finalensemble.xyz is written and the next step
+    ## (split_conformers) then fails with a misleading FileNotFoundError.
+    ## Fall back to serial so GOAT still runs on hosts without an MPI runtime.
+    if useCpus > 1 and shutil.which("mpirun") is None:
+        print("[drFrankenstein] WARNING: 'mpirun' not found on PATH; running GOAT "
+              "in serial (%PAL NPROCS 1). Install an MPI runtime matching your ORCA "
+              "build to parallelise GOAT.")
+        useCpus = 1
     with open(goatOrcaInput, "w") as f:
         f.write(" # --------------------------------- #\n")
         f.write(" #  GOAT conformation generation     #\n")


### PR DESCRIPTION
## Problem

`write_goat_input()` (`Laboratory/OperatingTools/drOrca.py`) always writes:

```
%PAL NPROCS {min(availableCpus, 16)} END
```

On a host **without an MPI runtime**, ORCA shells out to `mpirun` for any `NPROCS > 1` and aborts:

```
sh: 1: mpirun: not found
ORCA finished by error termination in orca_util
```

GOAT then writes no `*.finalensemble.xyz`, and the next step (`Protocol_2_Wriggling/Wriggling_Doctor.split_conformers`) fails with a misleading:

```
FileNotFoundError: GOAT final ensemble not found in .../02_GOAT_conformers
```

The real cause (`mpirun: not found`) is only visible in `02_GOAT_conformers/GOAT_orca.out`, not the traceback.

Notably, **every other ORCA step works without MPI**: the charge (Protocol_3) and torsion-scan (Protocol_5) stages honour `nCoresPerCalculation` and run serial ORCA jobs concurrently via a `multiprocessing.Pool` sized from `availableCpus`. GOAT was the only stage that hard-required an MPI runtime.

## Fix

Detect `mpirun` with `shutil.which` and fall back to `%PAL NPROCS 1` (with a warning) when it is absent. GOAT (XTB2 / GFN-FF) runs fine serially for small capped residues, and **parallel GOAT is unchanged on hosts that do have MPI**.

```python
if useCpus > 1 and shutil.which("mpirun") is None:
    print("[drFrankenstein] WARNING: 'mpirun' not found on PATH; running GOAT in serial ...")
    useCpus = 1
```

## Notes / alternatives
- A more configurable option would be an explicit `serial`/`nProcs` knob for GOAT, but auto-detection keeps existing configs working unchanged.
- Found while parameterising a hydroxyproline on an HPC node where ORCA was installed serial-only (no OpenMPI).