### PR TITLE
Support proline-type residues in enforce_default_backbone_charges

### DIFF
--- a/Laboratory/Experiments/Protocol_3_Charging/Charged_Assistant.py
+++ b/Laboratory/Experiments/Protocol_3_Charging/Charged_Assistant.py
@@ -25,12 +25,24 @@ AMBER19_DEFAULT_BACKBONE_CHARGES = {
     "O": -0.5679,
 }
 
+## Proline-type residues (PRO and 3-/4-hydroxyproline etc.) have a ring nitrogen
+## with no backbone amide hydrogen, so there is no "H" key. ff14SB/ff99SB PRO
+## backbone charges (same FF as AMBER19_DEFAULT_BACKBONE_CHARGES above).
+AMBER19_DEFAULT_BACKBONE_CHARGES_PROLINE = {
+    "N": -0.2548,
+    "CA": -0.0266,
+    "HA": 0.0641,
+    "C": 0.5896,
+    "O": -0.5748,
+}
+
 def _get_backbone_alias_atom_names(config: dict) -> list[str]:
     backboneAliases = config["moleculeInfo"]["backboneAliases"]
     requiredBackboneKeys = ["N", "H", "CA", "HA", "C", "O"]
     backboneAtoms = []
     for backboneKey in requiredBackboneKeys:
-        backboneAtoms.extend(backboneAliases[backboneKey])
+        ## .get() so proline-type residues (no backbone "H" alias) don't KeyError
+        backboneAtoms.extend(backboneAliases.get(backboneKey, []))
     return list(dict.fromkeys(backboneAtoms))
 
 def _rebalance_non_backbone_charges(
@@ -188,11 +200,21 @@ def enforce_default_backbone_charges(config: dict) -> dict:
 
     chargeDf = pd.read_csv(chargeCsv, index_col="Unnamed: 0")
 
-    requiredBackboneKeys = ["N", "H", "CA", "HA", "C", "O"]
+    ## Proline-type residues have a ring nitrogen with no backbone amide H.
+    ## Detect by the absence of an "H" backbone alias and use proline backbone
+    ## charges (still ff14SB) -- otherwise we either crash looking for a
+    ## non-existent H atom, or apply the standard-amine N charge to a ring N.
+    if backboneAliases.get("H"):
+        requiredBackboneKeys = ["N", "H", "CA", "HA", "C", "O"]
+        defaultBackboneCharges = AMBER19_DEFAULT_BACKBONE_CHARGES
+    else:
+        requiredBackboneKeys = ["N", "CA", "HA", "C", "O"]
+        defaultBackboneCharges = AMBER19_DEFAULT_BACKBONE_CHARGES_PROLINE
+
     aliasToCharge = {}
     for backboneKey in requiredBackboneKeys:
-        for alias in backboneAliases[backboneKey]:
-            aliasToCharge[alias] = AMBER19_DEFAULT_BACKBONE_CHARGES[backboneKey]
+        for alias in backboneAliases.get(backboneKey, []):
+            aliasToCharge[alias] = defaultBackboneCharges[backboneKey]
 
     for atomName, defaultCharge in aliasToCharge.items():
         atomMask = chargeDf["ATOM_NAME"] == atomName

--- a/Laboratory/OperatingTools/config_handler.py
+++ b/Laboratory/OperatingTools/config_handler.py
@@ -507,15 +507,18 @@ def _validate_backbone_charge_enforcement(config: Dict[str, Any], errors: Dict[s
     if not chargeFittingInfo.get("enforceDefaultBackboneCharges", False):
         return
     backboneAliases = moleculeInfo.get("backboneAliases")
-    requiredBackboneKeys = ["N", "H", "CA", "HA", "C", "O"]
     keyPathPrefix = "moleculeInfo.backboneAliases"
     if not isinstance(backboneAliases, dict):
         _add_error(
             errors,
             keyPathPrefix,
-            "When chargeFittingInfo.enforceDefaultBackboneCharges is True, moleculeInfo.backboneAliases must be a dictionary containing N, H, CA, HA, C, and O.",
+            "When chargeFittingInfo.enforceDefaultBackboneCharges is True, moleculeInfo.backboneAliases must be a dictionary containing N, CA, HA, C, O (and H for non-proline residues).",
         )
         return
+    ## Proline-type residues have a ring nitrogen with no backbone amide H, so an
+    ## "H" alias may be absent or empty; only require it for non-proline residues.
+    isProline = not backboneAliases.get("H")
+    requiredBackboneKeys = ["N", "CA", "HA", "C", "O"] if isProline else ["N", "H", "CA", "HA", "C", "O"]
     for backboneKey in requiredBackboneKeys:
         aliasKeyPath = f"{keyPathPrefix}.{backboneKey}"
         if backboneKey not in backboneAliases:

--- a/tests/test_proline_backbone_charges.py
+++ b/tests/test_proline_backbone_charges.py
@@ -105,5 +105,35 @@ class TestProlineBackboneCharges(unittest.TestCase):
             self.assertAlmostEqual(out["Charge"].sum(), 0.0, places=3)
 
 
+class TestProlineEnforceValidation(unittest.TestCase):
+    """The enforce cross-validation must accept proline configs (no backbone H alias).
+
+    Imports config_handler, which pulls the full runtime deps (ruamel/openmm/tqdm);
+    runs in the project's normal test environment (as the other suites already require).
+    """
+
+    def _validator(self):
+        from Laboratory.OperatingTools import config_handler
+        return config_handler._validate_backbone_charge_enforcement
+
+    def test_proline_config_passes_enforce_validation(self):
+        v = self._validator()
+        cfg = {"chargeFittingInfo": {"enforceDefaultBackboneCharges": True},
+               "moleculeInfo": {"backboneAliases":
+                   {"N": ["N"], "CA": ["CA"], "HA": ["HA"], "C": ["C"], "O": ["O"], "H": []}}}
+        errors = {}
+        v(cfg, errors)
+        self.assertEqual(errors, {})  # empty/absent H on a proline residue is valid
+
+    def test_proline_config_missing_CA_still_flagged(self):
+        v = self._validator()
+        cfg = {"chargeFittingInfo": {"enforceDefaultBackboneCharges": True},
+               "moleculeInfo": {"backboneAliases":
+                   {"N": ["N"], "HA": ["HA"], "C": ["C"], "O": ["O"], "H": []}}}  # CA missing
+        errors = {}
+        v(cfg, errors)
+        self.assertIn("moleculeInfo.backboneAliases.CA", errors)  # real gaps still caught
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_proline_backbone_charges.py
+++ b/tests/test_proline_backbone_charges.py
@@ -1,0 +1,109 @@
+"""Regression tests for proline-type backbone charge enforcement.
+
+Proline (and 3-/4-hydroxyproline) has a ring nitrogen with no backbone amide H.
+`enforce_default_backbone_charges` used to assume a standard backbone (it indexed
+`backboneAliases["H"]` and applied AMBER19_DEFAULT_BACKBONE_CHARGES["N"]), so a
+correct proline config (which omits the "H" alias) raised KeyError/ValueError.
+These tests pin the proline path and guard the standard path against regression.
+"""
+
+import os
+import sys
+import types
+import tempfile
+import unittest
+
+import numpy as np  # noqa: F401  (imported by module under test)
+import pandas as pd
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+LAB_ROOT = os.path.join(REPO_ROOT, "Laboratory")
+for _p in (REPO_ROOT, LAB_ROOT):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def _stub_heavy_imports():
+    """Charged_Assistant imports mdtraj / pdbUtils / project helpers at module load.
+    enforce_default_backbone_charges needs none of them, so stub them out."""
+    sys.modules.setdefault("mdtraj", types.ModuleType("mdtraj"))
+    if "pdbUtils" not in sys.modules:
+        pkg = types.ModuleType("pdbUtils")
+        pkg.pdbUtils = types.ModuleType("pdbUtils.pdbUtils")
+        sys.modules["pdbUtils"] = pkg
+        sys.modules["pdbUtils.pdbUtils"] = pkg.pdbUtils
+    ot = sys.modules.setdefault("OperatingTools", types.ModuleType("OperatingTools"))
+    for sub in ("file_parsers", "symmetry_tool"):
+        full = f"OperatingTools.{sub}"
+        if full not in sys.modules:
+            m = types.ModuleType(full)
+            sys.modules[full] = m
+            setattr(ot, sub, m)
+
+
+_stub_heavy_imports()
+
+from Laboratory.Experiments.Protocol_3_Charging import Charged_Assistant as CA
+
+
+def _write_charges_csv(path, rows):
+    # default index -> read back via index_col="Unnamed: 0", matching the module
+    pd.DataFrame(rows, columns=["ATOM_NAME", "Charge"]).to_csv(path)
+    return path
+
+
+class TestProlineBackboneCharges(unittest.TestCase):
+    def _config(self, chargeCsv, backboneAliases):
+        return {
+            "chargeFittingInfo": {"enforceDefaultBackboneCharges": True},
+            "moleculeInfo": {"charge": 0, "backboneAliases": backboneAliases},
+            "runtimeInfo": {"madeByCharges": {"chargesCsv": chargeCsv}},
+        }
+
+    def test_proline_without_backbone_H_uses_proline_charges(self):
+        rows = [
+            ["N", -0.30], ["CA", 0.10], ["HA", 0.05], ["C", 0.60], ["O", -0.55],
+            ["CB", -0.10], ["HB2", 0.05], ["HB3", 0.05],
+            ["CG", -0.10], ["HG2", 0.05], ["HG3", 0.05],
+            ["CD", 0.00], ["HD2", 0.05], ["HD3", 0.05],
+        ]
+        with tempfile.TemporaryDirectory() as d:
+            csv = _write_charges_csv(os.path.join(d, "charges.csv"), rows)
+            # proline backbone aliases deliberately omit "H"
+            aliases = {"N": ["N"], "CA": ["CA"], "HA": ["HA"], "C": ["C"], "O": ["O"]}
+
+            # must not raise (previously KeyError/ValueError on the missing H)
+            CA.enforce_default_backbone_charges(self._config(csv, aliases))
+
+            out = pd.read_csv(csv, index_col="Unnamed: 0")
+            byName = dict(zip(out["ATOM_NAME"], out["Charge"]))
+            self.assertAlmostEqual(byName["N"], -0.2548, places=4)
+            self.assertAlmostEqual(byName["CA"], -0.0266, places=4)
+            self.assertAlmostEqual(byName["HA"], 0.0641, places=4)
+            self.assertAlmostEqual(byName["C"], 0.5896, places=4)
+            self.assertAlmostEqual(byName["O"], -0.5748, places=4)
+            self.assertNotIn("H", byName)  # no spurious backbone amide H
+            self.assertAlmostEqual(out["Charge"].sum(), 0.0, places=3)
+
+    def test_standard_residue_with_H_unchanged(self):
+        rows = [
+            ["N", -0.30], ["H", 0.20], ["CA", 0.10], ["HA", 0.05], ["C", 0.60], ["O", -0.55],
+            ["CB", -0.10], ["HB1", 0.05], ["HB2", 0.05], ["HB3", 0.05],
+        ]
+        with tempfile.TemporaryDirectory() as d:
+            csv = _write_charges_csv(os.path.join(d, "charges.csv"), rows)
+            aliases = {"N": ["N"], "H": ["H"], "CA": ["CA"], "HA": ["HA"], "C": ["C"], "O": ["O"]}
+
+            CA.enforce_default_backbone_charges(self._config(csv, aliases))
+
+            out = pd.read_csv(csv, index_col="Unnamed: 0")
+            byName = dict(zip(out["ATOM_NAME"], out["Charge"]))
+            self.assertAlmostEqual(byName["N"], -0.4157, places=4)
+            self.assertAlmostEqual(byName["H"], 0.2719, places=4)
+            self.assertAlmostEqual(byName["CA"], 0.0337, places=4)
+            self.assertAlmostEqual(byName["C"], 0.5973, places=4)
+            self.assertAlmostEqual(out["Charge"].sum(), 0.0, places=3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Proline — and the hydroxyprolines (3-/4-Hyp) — have a **ring nitrogen with no backbone amide H**. A correct config therefore omits the `H` backbone alias. But `enforce_default_backbone_charges` (`Protocol_3_Charging/Charged_Assistant.py`) assumes a standard backbone:

```python
requiredBackboneKeys = ["N", "H", "CA", "HA", "C", "O"]
for backboneKey in requiredBackboneKeys:
    for alias in backboneAliases[backboneKey]:                       # KeyError if 'H' omitted
        aliasToCharge[alias] = AMBER19_DEFAULT_BACKBONE_CHARGES[backboneKey]
...
    if not atomMask.any():
        raise ValueError("Backbone alias atom 'H' was not found in fitted charge table.")
```

So a proline residue either:
- **KeyError** on `backboneAliases['H']` (when the H alias is correctly omitted), or
- **ValueError** `Backbone alias atom 'H' was not found in fitted charge table` (if `H: ['H']` is supplied to dodge the KeyError).

`_get_backbone_alias_atom_names` has the same hardcoded-key assumption.

There's also a subtler correctness issue: even reaching the assignment, applying the standard amine `N` charge (−0.4157) to a proline ring nitrogen is wrong — proline's backbone charges differ.

## Fix

- Add **`AMBER19_DEFAULT_BACKBONE_CHARGES_PROLINE`** — ff14SB/ff99SB PRO backbone charges (no `H`): `N −0.2548, CA −0.0266, HA 0.0641, C 0.5896, O −0.5748`.
- Detect proline by the **absence of an `H` backbone alias**; use the proline key set + charge table in that case, otherwise the standard one.
- Make `_get_backbone_alias_atom_names` use `backboneAliases.get(key, [])` so a missing alias never KeyErrors.

### On the force field
The existing dict is named `AMBER19_…` but its values are **ff14SB/ff99SB** (its ALA charges match `amino12.lib` exactly). I kept the proline values in the **same force field** for consistency (verified against `amino12.lib`; identical in `amino19.lib`). Didn't rename the existing dict to keep the diff focused.

## Tests

`tests/test_proline_backbone_charges.py`:
- proline config (no `H` alias) → no exception, backbone gets PRO charges, residue stays neutral;
- standard residue (with `H`) → unchanged (regression guard).

Both pass via `python -m unittest`.

## How it was found

Parameterising 3-hydroxy-L-proline with the ANTECHAMBER/AMBER path: charges completed, then `enforce_default_backbone_charges` raised the ValueError above because hydroxyproline has no backbone amide H.