### PR TITLE
Final lib uses the stitched (RESP) mol2, not the assembly (AM1-BCC) mol2

### DIFF
--- a/Laboratory/Experiments/Protocol_7_Creation/AMBER_creation.py
+++ b/Laboratory/Experiments/Protocol_7_Creation/AMBER_creation.py
@@ -202,7 +202,7 @@ def copy_final_frcmod(config: dict) -> dict:
 def get_capping_atom_ids(config: dict) -> list[int]:
     """Return the atom IDs that belong to the capping groups."""
 
-    cappedMol2 = config["runtimeInfo"]["madeByAssembly"]["cappedMol2"]
+    cappedMol2 = config["runtimeInfo"]["madeByStitching"]["moleculeMol2"]
     creationDir = config["runtimeInfo"]["madeByCreator"]["finalCreationDir"]
     tmpPdb = p.join(creationDir, "tmp.pdb")
     obabelCommand = ["obabel", "-i", "mol2", cappedMol2, "-O", tmpPdb]
@@ -221,7 +221,7 @@ def get_capping_atom_ids(config: dict) -> list[int]:
 
 def create_final_lib_and_mol2(cappingAtomIds: list[int], config: dict) -> None:
     """Create the final AMBER lib and mol2 files."""
-    cappedMol2 = config["runtimeInfo"]["madeByAssembly"]["cappedMol2"]
+    cappedMol2 = config["runtimeInfo"]["madeByStitching"]["moleculeMol2"]
     finalCreationDir = config["runtimeInfo"]["madeByCreator"]["finalCreationDir"]
     moleculeName = config["moleculeInfo"]["moleculeName"]
     finalMol2 = p.join(finalCreationDir, f"{moleculeName}.mol2")


### PR DESCRIPTION
## Problem

In `AMBER_creation.py`, final creation takes the **torsion-refit frcmod** from `madeByStitching` (correct) but reads the **mol2** from `madeByAssembly["cappedMol2"]` — the antechamber **AM1-BCC** mol2 produced back in stage `04_parameter_assembly`:

```python
# get_capping_atom_ids() and create_final_lib_and_mol2()
cappedMol2 = config["runtimeInfo"]["madeByAssembly"]["cappedMol2"]   # AM1-BCC
...
moleculeFrcmod = config["runtimeInfo"]["madeByStitching"]["moleculeFrcmod"]  # RESP/torsion-fit
```

But the **fitted RESP charges are injected into the stitched mol2** (`Protocol_6_Stitching` → `edit_mol2_partial_charges` writes them into `madeByStitching["moleculeMol2"]`). So the final `.lib`/`.mol2` ship the **AM1-BCC** charges, silently discarding the RESP charges the whole charge stage computed.

### Observed
For a hydroxyproline run, the final residue carried the stage-04 AM1-BCC charges and a **non-integer net charge (−0.073)** after cap removal, while the stitched mol2 had the correct RESP charges and **net 0.0000**. The values matched `madeByStitching["moleculeMol2"]` exactly once creation was pointed at it.

## Fix

Read the mol2 from `madeByStitching["moleculeMol2"]` in both `get_capping_atom_ids` and `create_final_lib_and_mol2`. The assembly and stitched mol2 are structurally identical (same atoms/types/order — only charges differ), so cap-atom-id detection is unchanged; only the final charges become the intended RESP set.

## Verification

After the fix, the final `HY3.mol2` charges match the RESP charge CSV to **0.0000** across all matched atoms, net charge ≈ 0.